### PR TITLE
Typo in “with” section

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -143,7 +143,7 @@ contributors: Robin Ricard
             <emu-clause id="sec-array.prototype.with">
                 <h1>Array.prototype.with ( _index_, _value_ )</h1>
 
-                <p>When the *unshifted* method is called, the following steps are taken:</p>
+                <p>When the *with* method is called, the following steps are taken:</p>
 
                 <emu-alg>
                     1. Let _O_ be ? ToObject(*this* value).


### PR DESCRIPTION
The “with” section references the “unshifted” method, but it should be the “with” method.